### PR TITLE
Use hashtbl based implementation for feature vectors

### DIFF
--- a/src/RFC.ml
+++ b/src/RFC.ml
@@ -398,7 +398,7 @@ let predict_OOB rng forest train =
   Utls.ht_iteri (fun i _oob_idx (truth, preds') ->
       let preds =
         let pred_labels = A.of_list preds' in
-        A.map (fun label -> (Feature_vector.zero, label)) pred_labels in
+        A.map (fun label -> (Feature_vector.zero (), label)) pred_labels in
       A.unsafe_set truth_preds i (truth, majority_class rng preds)
     ) oob_idx2preds;
   truth_preds

--- a/src/RFC.ml
+++ b/src/RFC.ml
@@ -7,7 +7,6 @@
 
 module A = BatArray
 module Ht = BatHashtbl
-module IntMap = BatMap.Int
 module IntSet = BatSet.Int
 module L = BatList
 module Log = Dolog.Log
@@ -15,7 +14,7 @@ module RNG = BatRandom.State
 
 open Printf
 
-type features = int IntMap.t
+type features = int Feature_vector.t
 type class_label = int
 
 type sample = features (* X *) *
@@ -30,11 +29,11 @@ type metric = Gini (* default *)
             | Shannon (* TODO; WARN: check min value is still 0.0 *)
             | MCC (* TODO; WARN: check min value is still 0.0 *)
 
-(* a feature with non constant value allows to discriminate samples *)
+(* A feature with non constant value allows to discriminate samples *)
 let collect_non_constant_features samples =
   let feat_vals = Ht.create 11 in
   A.iter (fun (features, _class_label) ->
-      IntMap.iter (fun feature value ->
+      Feature_vector.iter (fun feature value ->
           try
             let prev_values = Ht.find feat_vals feature in
             Ht.replace feat_vals feature (IntSet.add value prev_values)
@@ -51,7 +50,7 @@ let collect_non_constant_features samples =
     ) feat_vals []
 
 let feat_get feat features =
-  IntMap.find_default 0 feat features
+  Feature_vector.get feat features
 
 (* split a node *)
 (* FBR: maybe this can be accelerated:
@@ -64,38 +63,38 @@ let partition_samples feature threshold samples =
       value <= threshold
     ) samples
 
-let _partition_samples_index index feature threshold sample_indexes =
-  (* sample indexes with feat's val <= threshold *)
-  let le_set = IntMap.find threshold (IntMap.find feature index) in
-  A.partition (fun i ->
-      IntSet.mem i le_set
-    ) sample_indexes
+(* let _partition_samples_index index feature threshold sample_indexes =
+ *   (\* sample indexes with feat's val <= threshold *\)
+ *   let le_set = Feature_vector.find threshold (Feature_vector.find feature index) in
+ *   A.partition (fun i ->
+ *       IntSet.mem i le_set
+ *     ) sample_indexes *)
 
 (* for each (feat, threshold) pair, record the set of samples
    (just their indexes in fact) which have feat_val <= threshold *)
-let _index_samples samples =
-  let all_sample_indexes = (* [0..n-1] *)
-    let n = A.length samples in
-    IntSet.of_array (A.init n (fun i -> i)) in
-  let feat_vals = collect_non_constant_features samples in
-  L.fold_left (fun acc1 (feature, values) ->
-      IntMap.add feature
-        (fst
-           (IntSet.fold (fun threshold (acc2, rem_samples) ->
-                let left, right =
-                  IntSet.partition (fun i ->
-                      let features = fst samples.(i) in
-                      let value = feat_get feature features in
-                      value <= threshold
-                    ) rem_samples in
-                (* Log.info "feat: %d val: %d left: %d right: %d"
-                 *   feature threshold
-                 *   (IntSet.cardinal left) (IntSet.cardinal right); *)
-                (IntMap.add threshold left acc2, right)
-              ) values (IntMap.empty, all_sample_indexes)
-           )
-        ) acc1
-    ) IntMap.empty feat_vals
+(* let _index_samples samples =
+ *   let all_sample_indexes = (\* [0..n-1] *\)
+ *     let n = A.length samples in
+ *     IntSet.of_array (A.init n (fun i -> i)) in
+ *   let feat_vals = collect_non_constant_features samples in
+ *   L.fold_left (fun acc1 (feature, values) ->
+ *       Feature_vector.add feature
+ *         (fst
+ *            (IntSet.fold (fun threshold (acc2, rem_samples) ->
+ *                 let left, right =
+ *                   IntSet.partition (fun i ->
+ *                       let features = fst samples.(i) in
+ *                       let value = feat_get feature features in
+ *                       value <= threshold
+ *                     ) rem_samples in
+ *                 (\* Log.info "feat: %d val: %d left: %d right: %d"
+ *                  *   feature threshold
+ *                  *   (IntSet.cardinal left) (IntSet.cardinal right); *\)
+ *                 (Feature_vector.add threshold left acc2, right)
+ *               ) values (Feature_vector.empty, all_sample_indexes)
+ *            )
+ *         ) acc1
+ *     ) Feature_vector.empty feat_vals *)
 
 (* how many times we see each class label *)
 let class_count_samples samples =
@@ -399,7 +398,7 @@ let predict_OOB rng forest train =
   Utls.ht_iteri (fun i _oob_idx (truth, preds') ->
       let preds =
         let pred_labels = A.of_list preds' in
-        A.map (fun label -> (IntMap.empty, label)) pred_labels in
+        A.map (fun label -> (Feature_vector.zero, label)) pred_labels in
       A.unsafe_set truth_preds i (truth, majority_class rng preds)
     ) oob_idx2preds;
   truth_preds

--- a/src/RFC.mli
+++ b/src/RFC.mli
@@ -1,8 +1,7 @@
 
-module IntMap = BatMap.Int
 module IntSet = BatSet.Int
 
-type features = int IntMap.t
+type features = int Feature_vector.t
 type class_label = int
 
 type sample = features (* X *) *
@@ -78,10 +77,10 @@ val restore: filename -> forest
 (** The following are needed to implement RFR *)
 
 val collect_non_constant_features:
-  (int IntMap.t * 'a) array -> (int * IntSet.t) list
+  (int Feature_vector.t * 'a) array -> (int * IntSet.t) list
 
-val partition_samples: int -> int -> (int IntMap.t * 'a) array ->
-  (int IntMap.t * 'a) array * (int IntMap.t * 'a) array
+val partition_samples: int -> int -> (int Feature_vector.t * 'a) array ->
+  (int Feature_vector.t * 'a) array * (int Feature_vector.t * 'a) array
 
 val cost_function: ('a array -> float) -> 'a array -> 'a array -> float
 

--- a/src/RFR.ml
+++ b/src/RFR.ml
@@ -6,14 +6,13 @@
 (* Random Forests Regressor *)
 
 module A = BatArray
-module IntMap = BatMap.Int
 module IntSet = BatSet.Int
 module L = BatList
 module Log = Dolog.Log
 module RNG = Random.State
 module Ht = BatHashtbl
 
-type features = int IntMap.t
+type features = int Feature_vector.t
 type dep_var = float
 
 type sample = features (* X *) *
@@ -181,7 +180,7 @@ let tree_predict tree (features, _dep_var) =
   let rec loop = function
     | Leaf dep_var -> dep_var
     | Node (lhs, feature, threshold, rhs) ->
-      let value = IntMap.find_default 0 feature features in
+      let value = Feature_vector.get feature features in
       if value <= threshold then
         loop lhs
       else

--- a/src/RFR.mli
+++ b/src/RFR.mli
@@ -5,9 +5,7 @@
 
 (* Random Forests Regressor *)
 
-module IntMap = BatMap.Int
-
-type features = int IntMap.t
+type features = int Feature_vector.t
 type dep_var = float
 
 type sample = features (* X *) *

--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
 (library
  (name orf)
  (public_name orf)
- (modules RFC RFR utls)
+ (modules RFC RFR feature_vector utls)
  (private_modules utls)
  (libraries batteries cpm dolog parany line_oriented))
 

--- a/src/feature_vector.ml
+++ b/src/feature_vector.ml
@@ -1,0 +1,13 @@
+type feature = int
+
+module IntMap = BatMap.Int
+
+type 'a t = 'a IntMap.t
+
+let iter = IntMap.iter
+
+let zero = IntMap.empty
+
+let get f vec = IntMap.find_default 0 f vec
+
+let set = IntMap.add

--- a/src/feature_vector.ml
+++ b/src/feature_vector.ml
@@ -1,13 +1,11 @@
 type feature = int
 
-module IntMap = BatMap.Int
+type 'a t = (feature, 'a) Hashtbl.t
 
-type 'a t = 'a IntMap.t
+let iter f vec = Hashtbl.iter f vec
 
-let iter = IntMap.iter
+let zero () = Hashtbl.create 11
 
-let zero = IntMap.empty
+let get ft vec = try Hashtbl.find vec ft with Not_found -> 0
 
-let get f vec = IntMap.find_default 0 f vec
-
-let set = IntMap.add
+let set ft coeff vec = Hashtbl.replace vec ft coeff

--- a/src/feature_vector.mli
+++ b/src/feature_vector.mli
@@ -9,11 +9,11 @@ type 'a t
 val iter : (feature -> 'a -> unit) -> 'a t -> unit
 
 (** The zero feature vector. *)
-val zero : 'a t
+val zero : unit -> 'a t
 
 (** [get feature vec] returns the coefficient associated to [feature]
     in the integer-valued vector [vec]. *)
 val get : feature -> int t -> int
 
 (** [set feature coeff vec] sets the value of [vec] for [feature] to [coeff]. *)
-val set : feature -> 'a -> 'a t -> 'a t
+val set : feature -> 'a -> 'a t -> unit

--- a/src/feature_vector.mli
+++ b/src/feature_vector.mli
@@ -1,0 +1,19 @@
+(** A [feature] is encoded as an integer. *)
+type feature = int
+
+(** ['a t] is the type of feature vectors with features of type [int]
+    and coefficients of type ['a]. *)
+type 'a t
+
+(** Iterate on a feature vector. *)
+val iter : (feature -> 'a -> unit) -> 'a t -> unit
+
+(** The zero feature vector. *)
+val zero : 'a t
+
+(** [get feature vec] returns the coefficient associated to [feature]
+    in the integer-valued vector [vec]. *)
+val get : feature -> int t -> int
+
+(** [set feature coeff vec] sets the value of [vec] for [feature] to [coeff]. *)
+val set : feature -> 'a -> 'a t -> 'a t

--- a/src/model.ml
+++ b/src/model.ml
@@ -10,12 +10,12 @@ module Buff = Buffer
 module CLI = Minicli.CLI
 module Fn = Filename
 module Fp = Molenc.Fingerprint
-module IntMap = BatMap.Int
 module L = BatList
 module LO = Line_oriented
 module Log = Dolog.Log
 module Mol = Molenc.FpMol
 module RFR = Orf.RFR
+module Feature_vector = Orf.Feature_vector
 module Stats = Cpm.RegrStats
 
 type model_file_mode = Save of string
@@ -44,7 +44,7 @@ let train_test_NxCV nprocs train_fun test_fun nfolds training_set =
 (* Orf.RFR needs a samples array *)
 let samples_array_of_mols_list mols =
   let n = L.length mols in
-  let dummy = (IntMap.empty, 0.0) in
+  let dummy = (Feature_vector.zero, 0.0) in
   if n = 0 then
     let () = Log.warn "Model.samples_array_of_mols_list: no mols" in
     A.make 0 dummy

--- a/src/model.ml
+++ b/src/model.ml
@@ -44,7 +44,7 @@ let train_test_NxCV nprocs train_fun test_fun nfolds training_set =
 (* Orf.RFR needs a samples array *)
 let samples_array_of_mols_list mols =
   let n = L.length mols in
-  let dummy = (Feature_vector.zero, 0.0) in
+  let dummy = (Feature_vector.zero (), 0.0) in
   if n = 0 then
     let () = Log.warn "Model.samples_array_of_mols_list: no mols" in
     A.make 0 dummy

--- a/src/test.ml
+++ b/src/test.ml
@@ -5,12 +5,12 @@
 
 module A = BatArray
 module CLI = Minicli.CLI
-module IntMap = BatMap.Int
 module L = BatList
 module LO = Line_oriented
 module Log = Dolog.Log
 module RFC = Orf.RFC
 module RFR = Orf.RFR
+module Feature_vector = Orf.Feature_vector
 module S = BatString
 
 open Printf
@@ -18,9 +18,9 @@ open Printf
 let features_of_str_tokens toks =
   L.fold_left (fun acc tok_str ->
       Scanf.sscanf tok_str "%d:%d" (fun k v ->
-          IntMap.add k v acc
+          Feature_vector.set k v acc
         )
-    ) IntMap.empty toks
+    ) Feature_vector.zero toks
 
 let sample_of_csv_line l =
   let tokens = S.split_on_char ' ' l in

--- a/src/test.ml
+++ b/src/test.ml
@@ -16,11 +16,13 @@ module S = BatString
 open Printf
 
 let features_of_str_tokens toks =
-  L.fold_left (fun acc tok_str ->
+  let vec = Feature_vector.zero () in
+  L.iter (fun tok_str ->
       Scanf.sscanf tok_str "%d:%d" (fun k v ->
-          Feature_vector.set k v acc
-        )
-    ) Feature_vector.zero toks
+          Feature_vector.set k v vec
+      )
+    ) toks ;
+  vec
 
 let sample_of_csv_line l =
   let tokens = S.split_on_char ' ' l in

--- a/src/utls.ml
+++ b/src/utls.ml
@@ -9,14 +9,10 @@ module A = BatArray
 module Fn = Filename
 module Ht = BatHashtbl
 module IS = BatSet.Int
-module IntMap = BatMap.Int
 module IntSet = BatSet.Int
 module L = BatList
 module LO = Line_oriented
 module Log = Dolog.Log
-
-(* sparse vector of integer features *)
-type features = int IntMap.t
 
 type filename = string
 

--- a/test
+++ b/test
@@ -1,1 +1,1 @@
-/home/berenger/src/orf/_build/default/src/test.exe
+_build/default/src/test.exe


### PR DESCRIPTION
This PR does two things:
- Abstract away feature vectors in a dedicated module (this should also make it easier to use float coefficients instead of integer ones)
- Use an imperative, hashtbl based implementation instead of the one based on int maps.

This allows to get slightly faster training.